### PR TITLE
Add support for variable tag sizes to chacha20poly1305

### DIFF
--- a/chacha/chachaPoly1305.go
+++ b/chacha/chachaPoly1305.go
@@ -45,7 +45,7 @@ func (c *aeadCipher) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	var Nonce [12]byte
 	copy(Nonce[:], nonce)
 
-	// create the ploy1305 key
+	// create the poly1305 key
 	var polyKey [32]byte
 	XORKeyStream(polyKey[:], polyKey[:], &(c.key), &Nonce, 0)
 
@@ -74,7 +74,7 @@ func (c *aeadCipher) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte
 	hash := ciphertext[len(ciphertext)-poly1305.TagSize:]
 	ciphertext = ciphertext[:len(ciphertext)-poly1305.TagSize]
 
-	// create the ploy1305 key
+	// create the poly1305 key
 	var polyKey [32]byte
 	XORKeyStream(polyKey[:], polyKey[:], &(c.key), &Nonce, 0)
 


### PR DESCRIPTION
We are currently implementing the [QUIC](https://en.wikipedia.org/wiki/QUIC) protocol at https://github.com/lucas-clemente/quic-go, and needed the chacha20poly1305 cipher with a non-standard tag size of 12 bytes. I looked at a number of go implementations, but found yours the easiest to adapt :)
